### PR TITLE
Use sassc compatible gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,11 +2,11 @@ source 'https://rubygems.org'
 
 ruby "2.6.0"
 
-gem "bourbon", "5.0.0.beta.6"
+gem "bourbon", ">= 5.1.0"
 gem "middleman", ">= 4.0.0"
 gem "middleman-autoprefixer"
 gem "middleman-livereload"
 gem "middleman-minify-html"
-gem "neat", "2.0.0.beta.1"
+gem "neat", ">= 3.0.1"
 gem "redcarpet"
 gem "slim"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,9 +11,9 @@ GEM
     autoprefixer-rails (8.6.5)
       execjs
     backports (3.11.4)
-    bourbon (5.0.0.beta.6)
-      sass (~> 3.4.22)
-      thor (~> 0.19.1)
+    bourbon (5.1.0)
+      sass (~> 3.4)
+      thor (~> 0.19)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
@@ -87,7 +87,7 @@ GEM
       htmlcompressor (~> 0.2.0)
       middleman-core (>= 3.2)
     minitest (5.11.3)
-    neat (2.0.0.beta.1)
+    neat (3.0.1)
       sass (~> 3.4)
       thor (~> 0.19)
     padrino-helpers (0.13.3.4)
@@ -106,7 +106,11 @@ GEM
     rb-inotify (0.10.0)
       ffi (~> 1.0)
     redcarpet (3.4.0)
-    sass (3.4.25)
+    sass (3.7.3)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
     sassc (2.0.0)
       ffi (~> 1.9.6)
       rake
@@ -127,12 +131,12 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bourbon (= 5.0.0.beta.6)
+  bourbon (>= 5.1.0)
   middleman (>= 4.0.0)
   middleman-autoprefixer
   middleman-livereload
   middleman-minify-html
-  neat (= 2.0.0.beta.1)
+  neat (>= 3.0.1)
   redcarpet
   slim
 


### PR DESCRIPTION
The middleman update in 14a9a20781e33d732c2d26fbcb10105baa5d066d
also ended up introducing sassc as a dependency. The versions of bourbon
and neat previously in the Gemfile do not work with sassc,
and https://baccano.io/ currently shows a SassC::SyntaxError on the
page. The latest versions of bourbon and neat should work fine with
sassc.